### PR TITLE
feat: remove dark mode completely and enforce light mode only

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -53,7 +53,7 @@ export default function Footer() {
                     </a>
                 </li>
             </ul> */}
-            <p className="mt-8 text-neutral-600 dark:text-neutral-300">
+            <p className="mt-8 text-neutral-600">
                 © {new Date().getFullYear()} by yours truly
             </p>
         </footer>

--- a/app/components/keyEsc.tsx
+++ b/app/components/keyEsc.tsx
@@ -74,7 +74,7 @@ export function KeyEsc({ context = "fixed" }: KeyEscProps) {
 
     // Base classes for appearance (size, color, shadow, etc.)
     const baseClasses =
-        "h-10 w-10 rounded-lg border border-black/10 dark:border-white/10 bg-orange-500 text-white hover:bg-orange-600 focus:outline-none dark:bg-orange-600 dark:hover:bg-orange-700 dark:focus:ring-offset-black transition-transform duration-75 ease-in-out shadow-[0_3px_0_0_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.2)] font-medium text-xs";
+        "h-10 w-10 rounded-lg border border-black/10 bg-orange-500 text-white hover:bg-orange-600 focus:outline-none transition-transform duration-75 ease-in-out shadow-[0_3px_0_0_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.2)] font-medium text-xs";
 
     // Active state classes (from the original active: pseudo-classes)
     const activeClasses =

--- a/app/components/nav.tsx
+++ b/app/components/nav.tsx
@@ -68,13 +68,13 @@ export function Navbar() {
             ([path, { name, external }], index) => {
                 const isCurrentPage = !external && isActive(path);
 
-                const baseClasses = `transition-all duration-300 ease-in-out px-3 border-r border-gray-200 dark:border-gray-800 last:border-r-0 hover:text-neutral-800 dark:hover:text-neutral-200 flex relative py-2 items-center gap-2`;
+                const baseClasses = `transition-all duration-300 ease-in-out px-3 border-r border-gray-200 last:border-r-0 hover:text-neutral-800 flex relative py-2 items-center gap-2`;
                 const mobileBaseClasses = isMobile
                     ? "text-lg py-2 border-r-0"
                     : "";
 
                 const activeClasses = isCurrentPage
-                    ? "text-neutral-900 dark:text-neutral-100 font-medium"
+                    ? "text-neutral-900 font-medium"
                     : "";
 
                 const mobileAnimationClasses = isMobile
@@ -149,13 +149,13 @@ export function Navbar() {
                     className="hidden md:flex md:flex-row md:items-center relative px-0 pb-0 fade md:overflow-auto scroll-pr-6"
                     id="desktop-nav"
                 >
-                    <div className="flex flex-row bg-white/80 dark:bg-black/80 backdrop-blur-md border border-gray-200 dark:border-gray-800 rounded-lg transition-all duration-300 ease-in-out">
+                    <div className="flex flex-row bg-white/80 backdrop-blur-md border border-gray-200 rounded-lg transition-all duration-300 ease-in-out">
                         {renderLinks(false)}
                     </div>
                 </nav>
 
                 <div
-                    className={`fixed inset-0 z-40 bg-white/95 dark:bg-black/95 backdrop-blur-sm flex flex-col items-center justify-center md:hidden transition-opacity duration-300 ease-in-out ${
+                    className={`fixed inset-0 z-40 bg-white/95 backdrop-blur-sm flex flex-col items-center justify-center md:hidden transition-opacity duration-300 ease-in-out ${
                         isMobileMenuOpen
                             ? "opacity-100 pointer-events-auto"
                             : "opacity-0 pointer-events-none"

--- a/app/components/posts.tsx
+++ b/app/components/posts.tsx
@@ -17,10 +17,10 @@ export function BlogPosts({ posts }: BlogPostsProps = {}) {
                     href={`/writings/${post.slug}`}
                 >
                     <div className="w-full flex flex-col md:flex-row space-x-0 md:space-x-2">
-                        <p className="text-neutral-600 dark:text-neutral-400 w-[160px] tabular-nums shrink-0">
+                        <p className="text-neutral-600 w-[160px] tabular-nums shrink-0">
                             {formatDate(post.metadata.publishedAt, false)}
                         </p>
-                        <p className="text-neutral-900 dark:text-neutral-100 tracking-tight">
+                        <p className="text-neutral-900 tracking-tight">
                             {post.metadata.title}
                         </p>
                     </div>

--- a/app/components/showcase-projects.tsx
+++ b/app/components/showcase-projects.tsx
@@ -139,13 +139,10 @@ const projects: Project[] = [
 
 // Category color mapping for chips
 const categoryColors: Record<Category, string> = {
-    Component: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
-    "Mobile App":
-        "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-    Website:
-        "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200",
-    "Web App":
-        "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+    Component: "bg-blue-100 text-blue-800",
+    "Mobile App": "bg-green-100 text-green-800",
+    Website: "bg-purple-100 text-purple-800",
+    "Web App": "bg-orange-100 text-orange-800",
 };
 
 export function ShowcaseProjects() {
@@ -195,7 +192,7 @@ function ProjectCard({ project }: { project: Project }) {
         project.assetType === "video" || isVideoUrl(project.assetUrl);
 
     return (
-        <div className="w-full h-full overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700 bg-card text-card-foreground flex flex-col group transition-shadow duration-200 ease-in-out hover:shadow-md">
+        <div className="w-full h-full overflow-hidden rounded-lg border border-gray-200 bg-card text-card-foreground flex flex-col group transition-shadow duration-200 ease-in-out hover:shadow-md">
             <div className="aspect-video overflow-hidden">
                 {shouldRenderAsVideo ? (
                     <video
@@ -222,7 +219,7 @@ function ProjectCard({ project }: { project: Project }) {
                     />
                 )}
             </div>
-            <div className="border-t border-gray-200 dark:border-gray-700" />
+            <div className="border-t border-gray-200" />
             <div className="p-4 flex flex-col flex-grow">
                 <div className="flex items-start justify-between gap-2 mb-2">
                     <h3 className="text-lg font-semibold text-foreground flex-1">

--- a/app/global.css
+++ b/app/global.css
@@ -29,31 +29,10 @@
     --radius: 0.5rem;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --sh-class: #4c97f8;
-        --sh-identifier: white;
-        --sh-keyword: #f47067;
-        --sh-string: #0fa295;
-
-        --background: 222.2 84% 4.9%;
-        --foreground: 210 40% 98%;
-
-        --muted: 217.2 32.6% 17.5%;
-        --muted-foreground: 215 20.2% 65.1%;
-
-        --border: 217.2 32.6% 17.5%;
-        --input: 217.2 32.6% 17.5%;
-        --ring: 212.7 26.8% 83.9%;
-    }
-    html {
-        color-scheme: dark;
-    }
-}
-
 html {
     min-width: 360px;
     scroll-behavior: smooth;
+    color-scheme: light; /* Force light mode */
 }
 
 .prose .anchor {
@@ -71,11 +50,11 @@ html {
 }
 
 .prose a {
-    @apply underline transition-all decoration-neutral-400 dark:decoration-neutral-600 underline-offset-2 decoration-[0.1em];
+    @apply underline transition-all decoration-neutral-400 underline-offset-2 decoration-[0.1em];
 }
 
 .prose .anchor:after {
-    @apply text-neutral-300 dark:text-neutral-700;
+    @apply text-neutral-300;
     content: "#";
 }
 
@@ -84,7 +63,7 @@ html {
 }
 
 .prose pre {
-    @apply bg-neutral-50 dark:bg-neutral-900 rounded-lg overflow-x-auto border border-neutral-200 dark:border-neutral-900 py-2 px-3 text-sm;
+    @apply bg-neutral-50 rounded-lg overflow-x-auto border border-neutral-200 py-2 px-3 text-sm;
 }
 
 .prose code {
@@ -107,7 +86,7 @@ html {
 }
 
 .prose p {
-    @apply my-4 text-neutral-800 dark:text-neutral-200;
+    @apply my-4 text-neutral-800;
 }
 
 .prose h1 {
@@ -175,16 +154,4 @@ table {
 /* Custom definition for text-muted-foreground */
 .text-muted-foreground {
     @apply text-[hsl(var(--muted-foreground))];
-}
-
-/* Ensure dark mode also works if needed */
-@media (prefers-color-scheme: dark) {
-    /* ... existing dark mode :root variables ... */
-
-    .text-muted-foreground {
-        /* Use the dark mode variable value */
-        @apply text-[hsl(var(--muted-foreground))];
-        /* OR you could hardcode if variables aren't reliable */
-        /* @apply text-[hsl(215_20.2%_65.1%)]; */
-    }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,29 +46,9 @@ export default function RootLayout({
             suppressHydrationWarning
         >
             <head>
-                <script
-                    dangerouslySetInnerHTML={{
-                        __html: `
-                            (function() {
-                                function getInitialTheme() {
-                                    if (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) {
-                                        return localStorage.getItem('theme');
-                                    }
-                                    if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                                        return 'dark';
-                                    }
-                                    return 'light';
-                                }
-
-                                const theme = getInitialTheme();
-                                document.documentElement.classList.add(theme);
-                                localStorage.setItem('theme', theme);
-                            })();
-                        `,
-                    }}
-                />
+                {/* Theme detection script removed - fixed to light mode only */}
             </head>
-            <body className="text-black dark:text-white max-w-xl mx-auto mt-8 antialiased">
+            <body className="text-black max-w-xl mx-auto mt-8 antialiased">
                 <main className="flex-auto min-w-0 mt-6 flex flex-col px-2 md:px-0">
                     <Navbar />
                     {children}

--- a/app/showcase/timepicker/page.tsx
+++ b/app/showcase/timepicker/page.tsx
@@ -24,7 +24,7 @@ export default function TimepickerShowcase() {
                 Time Picker Component
             </h1>
 
-            <p className="text-neutral-600 dark:text-neutral-400 mb-12 max-w-2xl">
+            <p className="text-neutral-600 mb-12 max-w-2xl">
                 A clean and interactive time picker component with input field
                 trigger and dropdown selection. Supports both 12-hour and
                 24-hour formats with keyboard and mouse interactions.
@@ -36,9 +36,9 @@ export default function TimepickerShowcase() {
                         <h2 className="text-lg font-semibold mb-2">
                             12-Hour Format
                         </h2>
-                        <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3">
+                        <p className="text-sm text-neutral-600 mb-3">
                             Selected:{" "}
-                            <span className="font-mono bg-neutral-100 dark:bg-neutral-800 px-2 py-1 rounded">
+                            <span className="font-mono bg-neutral-100 px-2 py-1 rounded">
                                 {time12h || "None"}
                             </span>
                         </p>
@@ -57,9 +57,9 @@ export default function TimepickerShowcase() {
                         <h2 className="text-lg font-semibold mb-2">
                             24-Hour Format
                         </h2>
-                        <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3">
+                        <p className="text-sm text-neutral-600 mb-3">
                             Selected:{" "}
-                            <span className="font-mono bg-neutral-100 dark:bg-neutral-800 px-2 py-1 rounded">
+                            <span className="font-mono bg-neutral-100 px-2 py-1 rounded">
                                 {time24h || "None"}
                             </span>
                         </p>

--- a/app/writings/page.tsx
+++ b/app/writings/page.tsx
@@ -19,7 +19,7 @@ export default function Page() {
             {/* Case Studies Section */}
             {caseStudyPosts.length > 0 && (
                 <div className="mb-12">
-                    <h2 className="font-semibold text-xl mb-6 tracking-tight text-neutral-800 dark:text-neutral-200">
+                    <h2 className="font-semibold text-xl mb-6 tracking-tight text-neutral-800">
                         Case Studies
                     </h2>
                     <BlogPosts posts={caseStudyPosts} />
@@ -29,7 +29,7 @@ export default function Page() {
             {/* Blog Posts Section */}
             {blogPosts.length > 0 && (
                 <div>
-                    <h2 className="font-semibold text-xl mb-6 tracking-tight text-neutral-800 dark:text-neutral-200">
+                    <h2 className="font-semibold text-xl mb-6 tracking-tight text-neutral-800">
                         Blog Posts
                     </h2>
                     <BlogPosts posts={blogPosts} />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
         "./components/**/*.{js,ts,jsx,tsx,mdx}",
         "./app/**/*.{js,ts,jsx,tsx,mdx}",
     ],
+    darkMode: false, // Disable dark mode entirely
     theme: {
         extend: {},
     },


### PR DESCRIPTION
- Disable dark mode in Tailwind config (darkMode: false)
- Remove all @media (prefers-color-scheme: dark) queries from global.css
- Remove theme detection script from layout.tsx
- Remove all dark: classes from components:
  - nav.tsx: navigation styling
  - keyEsc.tsx: escape key button styling
  - footer.tsx: footer text styling
  - posts.tsx: blog post link styling
  - showcase-projects.tsx: project card styling
- Remove dark mode classes from showcase pages:
  - timepicker/page.tsx: component showcase styling
  - writings/page.tsx: section header styling
- Add color-scheme: light to force light mode
- Site now renders in light mode only regardless of system preference